### PR TITLE
Add Dump(), Md5(), and Sha1(), rework struct tags, improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# structhash
+# structhash [![GoDoc](https://godoc.org/github.com/cnf/structhash?status.svg)](https://godoc.org/github.com/cnf/structhash)
 
 structhash is a Go library for generating hash strings of arbitrary data structures.
 

--- a/README.md
+++ b/README.md
@@ -70,22 +70,22 @@ func main() {
 structhash supports struct tags in the following forms:
 
 * `hash:"-"`, or
-* `hash:"name, version(number) lastversion(number)"`
+* `hash:"name:{string} version:{number} lastversion:{number}"`
 
 All fields are optional and may be ommitted. Their semantics is:
 
 * `-` - ignore field
-* `name` - rename field (may be useful when you want to rename field but keep hashes backward compatible)
-* `version(number)` - ignore field if version passed to structhash is lesser than given number
-* `lastversion(number)` - ignore field if version passed to structhash is greater than given number
+* `name:{string}` - rename field (may be useful when you want to rename field but keep hashes unchanged for backward compatibility)
+* `version:{number}` - ignore field if version passed to structhash is lesser than given number
+* `lastversion:{number}` - ignore field if version passed to structhash is greater than given number
 
 Example:
 
 ```go
 type MyStruct struct {
     Ignored string `hash:"-"`
-    Renamed string `hash:"NewName, version(1)"`
-    Legacy  int    `hash:",version(1) lastversion(2)"`
+    Renamed string `hash:"name:OldName version:1"`
+    Legacy  string `hash:"version:1 lastversion:2"`
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,3 +54,27 @@ func main() {
     // Prints: 00f550e11183e2bb70f8bf12699c3866e5c8fcb3
 }
 ```
+
+## Struct tags
+
+structhash supports struct tags in the following forms:
+
+* `hash:"-"`, or
+* `hash:"name, version(number) lastversion(number)"`
+
+All fields are optional and may be ommitted. Their semantics is:
+
+* `-` - ignore field
+* `name` - rename field (may be useful when you want to rename field but keep hashes backward compatible)
+* `version(number)` - ignore field if version passed to structhash is lesser than given number
+* `lastversion(number)` - ignore field if version passed to structhash is greater than given number
+
+Example:
+
+```go
+type Person struct {
+    Ignored string `hash:"-"`
+    Renamed string `hash:"NewName, version(1)"`
+    Legacy  int    `hash:",version(1) lastversion(2)"`
+}
+```

--- a/README.md
+++ b/README.md
@@ -14,3 +14,43 @@ $ go get github.com/cnf/structhash
 
 For usage and examples see the [Godoc](http://godoc.org/github.com/cnf/structhash).
 
+## Quick start
+
+```go
+package main
+
+import (
+    "fmt"
+    "crypto/md5"
+    "crypto/sha1"
+    "github.com/gavv/structhash"
+)
+
+type S struct {
+    Str string
+    Num int
+}
+
+func main() {
+    s := S{"hello", 123}
+
+    hash, err := structhash.Hash(s, 1)
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(hash)
+    // Prints: v1_55743877f3ffd5fc834e97bc43a6e7bd
+
+    fmt.Printf("%x\n", structhash.Md5(s, 1))
+    // Prints: 55743877f3ffd5fc834e97bc43a6e7bd
+
+    fmt.Printf("%x\n", structhash.Sha1(s, 1))
+    // Prints: 00f550e11183e2bb70f8bf12699c3866e5c8fcb3
+
+    fmt.Printf("%x\n", md5.Sum(structhash.Dump(s, 1)))
+    // Prints: 55743877f3ffd5fc834e97bc43a6e7bd
+
+    fmt.Printf("%x\n", sha1.Sum(structhash.Dump(s, 1)))
+    // Prints: 00f550e11183e2bb70f8bf12699c3866e5c8fcb3
+}
+```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 structhash is a Go library for generating hash strings of arbitrary data structures.
 
+## Features
+
+* fields may be ignored or renamed (like in `json.Marshal`, but using different struct tag)
+* fields may be versioned
+* fields order in struct doesn't matter (unlike `json.Marshal`)
+* nil values are treated equally to zero values
+
 ## Installation
 
 Standard `go get`:
@@ -23,7 +30,7 @@ import (
     "fmt"
     "crypto/md5"
     "crypto/sha1"
-    "github.com/gavv/structhash"
+    "github.com/cnf/structhash"
 )
 
 type S struct {
@@ -39,19 +46,22 @@ func main() {
         panic(err)
     }
     fmt.Println(hash)
-    // Prints: v1_55743877f3ffd5fc834e97bc43a6e7bd
+    // Prints: v1_41011bfa1a996db6d0b1075981f5aa8f
+
+    fmt.Println(structhash.Version(hash))
+    // Prints: 1
 
     fmt.Printf("%x\n", structhash.Md5(s, 1))
-    // Prints: 55743877f3ffd5fc834e97bc43a6e7bd
+    // Prints: 41011bfa1a996db6d0b1075981f5aa8f
 
     fmt.Printf("%x\n", structhash.Sha1(s, 1))
-    // Prints: 00f550e11183e2bb70f8bf12699c3866e5c8fcb3
+    // Prints: 5ff72df7212ce8c55838fb3ec6ad0c019881a772
 
     fmt.Printf("%x\n", md5.Sum(structhash.Dump(s, 1)))
-    // Prints: 55743877f3ffd5fc834e97bc43a6e7bd
+    // Prints: 41011bfa1a996db6d0b1075981f5aa8f
 
     fmt.Printf("%x\n", sha1.Sum(structhash.Dump(s, 1)))
-    // Prints: 00f550e11183e2bb70f8bf12699c3866e5c8fcb3
+    // Prints: 5ff72df7212ce8c55838fb3ec6ad0c019881a772
 }
 ```
 
@@ -72,9 +82,13 @@ All fields are optional and may be ommitted. Their semantics is:
 Example:
 
 ```go
-type Person struct {
+type MyStruct struct {
     Ignored string `hash:"-"`
     Renamed string `hash:"NewName, version(1)"`
     Legacy  int    `hash:",version(1) lastversion(2)"`
 }
 ```
+
+## Nil values
+
+When hash is calculated, nil pointers, nil slices, and nil maps are treated equally to zero values of corresponding type. E.g., nil pointer to string is equivalent to empty string, and nil slice is equivalent to empty slice.

--- a/structhash.go
+++ b/structhash.go
@@ -175,30 +175,24 @@ func serialize(object interface{}, version int) string {
 			}
 		}
 		if str := f.Tag.Get("hash"); str != "" {
-			parts := strings.Split(str, ",")
-			if len(parts) > 0 {
-				n := strings.TrimSpace(parts[0])
-				if n == "-" {
-					return "", false
-				} else if n != "" {
-					name = n
-				}
+			if str == "-" {
+				return "", false
 			}
-			if len(parts) > 1 {
-				for _, tag := range strings.Split(parts[1], " ") {
-					tag = strings.TrimSpace(tag)
-					if strings.HasPrefix(tag, "version(") {
-						arg := strings.TrimPrefix(tag, "version(")
-						arg = strings.TrimSuffix(arg, ")")
-						if ver, err = strconv.Atoi(arg); err != nil {
-							return "", false
-						}
-					} else if strings.HasPrefix(tag, "lastversion(") {
-						arg := strings.TrimPrefix(tag, "lastversion(")
-						arg = strings.TrimSuffix(arg, ")")
-						if lastver, err = strconv.Atoi(arg); err != nil {
-							return "", false
-						}
+			for _, tag := range strings.Split(str, " ") {
+				args := strings.Split(strings.TrimSpace(tag), ":")
+				if len(args) != 2 {
+					return "", false
+				}
+				switch args[0] {
+				case "name":
+					name = args[1]
+				case "version":
+					if ver, err = strconv.Atoi(args[1]); err != nil {
+						return "", false
+					}
+				case "lastversion":
+					if lastver, err = strconv.Atoi(args[1]); err != nil {
+						return "", false
 					}
 				}
 			}

--- a/structhash.go
+++ b/structhash.go
@@ -2,6 +2,7 @@ package structhash
 
 import (
 	"crypto/md5"
+	"crypto/sha1"
 	"fmt"
 	"reflect"
 	"sort"
@@ -29,10 +30,32 @@ func Version(h string) int {
 }
 
 // Hash takes a data structure and returns a hash string of that data structure
-// at the version asked
+// at the version asked.
+//
+// This function uses md5 hashing function and default formatter. See also Dump()
+// function.
 func Hash(c interface{}, version int) (string, error) {
-	serial := serialize(c, version)
-	return fmt.Sprintf("v%d_%x", version, md5.Sum([]byte(serial))), nil
+	return fmt.Sprintf("v%d_%x", version, Md5(c, version)), nil
+}
+
+// Dump takes a data structure and returns its byte representation. This can be
+// useful if you need to use your own hashing function or formatter.
+func Dump(c interface{}, version int) []byte {
+	return []byte(serialize(c, version))
+}
+
+// Md5 takes a data structure and returns its md5 hash.
+// This is a shorthand for md5.Sum(Dump(c, version)).
+func Md5(c interface{}, version int) []byte {
+	sum := md5.Sum(Dump(c, version))
+	return sum[:]
+}
+
+// Sha1 takes a data structure and returns its sha1 hash.
+// This is a shorthand for sha1.Sum(Dump(c, version)).
+func Sha1(c interface{}, version int) []byte {
+	sum := sha1.Sum(Dump(c, version))
+	return sum[:]
 }
 
 type structFieldFilter func(reflect.StructField) bool

--- a/structhash.go
+++ b/structhash.go
@@ -74,7 +74,11 @@ func strValue(val reflect.Value, depth int, fltr structFieldFilter) string {
 		}
 		return "false"
 	case reflect.Ptr:
-		return strValue(reflect.Indirect(val), depth, fltr)
+		if !val.IsNil() || val.Type().Elem().Kind() == reflect.Struct {
+			return strValue(reflect.Indirect(val), depth, fltr)
+		} else {
+			return strValue(reflect.Zero(val.Type().Elem()), depth, fltr)
+		}
 	case reflect.Array, reflect.Slice:
 		len := val.Len()
 		ret := "["
@@ -113,7 +117,6 @@ func strValue(val reflect.Value, depth int, fltr structFieldFilter) string {
 		ret = ret + "]"
 		return ret
 	case reflect.Struct:
-
 		vtype := val.Type()
 		flen := vtype.NumField()
 		smap := make(map[string]string)

--- a/structhash_examples_test.go
+++ b/structhash_examples_test.go
@@ -43,12 +43,12 @@ func ExampleHash() {
 
 func ExampleHash_tags() {
 	type Person struct {
-		Ignored  string            `hash:"-"`
-		NewName  string            `hash:"name:OldName version:1"`
-		Age      int               `hash:"version:1"`
-		Emails   []string          `hash:"version:1"`
-		Extra    map[string]string `hash:"version:1 lastversion:2"`
-		Spouse   *Person           `hash:"version:2"`
+		Ignored string            `hash:"-"`
+		NewName string            `hash:"name:OldName version:1"`
+		Age     int               `hash:"version:1"`
+		Emails  []string          `hash:"version:1"`
+		Extra   map[string]string `hash:"version:1 lastversion:2"`
+		Spouse  *Person           `hash:"version:2"`
 	}
 	bill := &Person{
 		NewName: "Bill",

--- a/structhash_examples_test.go
+++ b/structhash_examples_test.go
@@ -44,24 +44,24 @@ func ExampleHash() {
 func ExampleHash_tags() {
 	type Person struct {
 		Ignored  string            `hash:"-"`
-		FullName string            `hash:"Name, version(1)"`
-		Age      int               `hash:",version(1)"`
-		Emails   []string          `hash:",version(1)"`
-		Extra    map[string]string `hash:",version(1) lastversion(2)"`
-		Spouse   *Person           `hash:",version(2)"`
+		NewName  string            `hash:"name:OldName version:1"`
+		Age      int               `hash:"version:1"`
+		Emails   []string          `hash:"version:1"`
+		Extra    map[string]string `hash:"version:1 lastversion:2"`
+		Spouse   *Person           `hash:"version:2"`
 	}
 	bill := &Person{
-		FullName: "Bill",
-		Age:      24,
-		Emails:   []string{"bob@foo.org", "bob@bar.org"},
+		NewName: "Bill",
+		Age:     24,
+		Emails:  []string{"bob@foo.org", "bob@bar.org"},
 		Extra: map[string]string{
 			"facebook": "Bob42",
 		},
 	}
 	bob := &Person{
-		FullName: "Bob",
-		Age:      42,
-		Emails:   []string{"bob@foo.org", "bob@bar.org"},
+		NewName: "Bob",
+		Age:     42,
+		Emails:  []string{"bob@foo.org", "bob@bar.org"},
 		Extra: map[string]string{
 			"facebook": "Bob42",
 		},
@@ -83,9 +83,9 @@ func ExampleHash_tags() {
 	fmt.Printf("%s\n", hashV2)
 	fmt.Printf("%s\n", hashV3)
 	// Output:
-	// v1_461558d2570e10f79693e34ea309d1ad
-	// v2_d00068b9441e09d87689c7cb06a646a1
-	// v3_b5b651c6650939ef4d063d05caa5c778
+	// v1_a4500d206f830e75bb4b362705ee6240
+	// v2_67caf9d9f9d2922ecc6f997bace6f06c
+	// v3_a10f69ec95d652fc16f5f744a554e624
 }
 
 func ExampleDump() {

--- a/structhash_examples_test.go
+++ b/structhash_examples_test.go
@@ -1,9 +1,9 @@
 package structhash
 
 import (
-	"fmt"
 	"crypto/md5"
 	"crypto/sha1"
+	"fmt"
 )
 
 func ExampleHash() {
@@ -38,29 +38,30 @@ func ExampleHash() {
 	}
 	fmt.Printf("%s", hash)
 	// Output:
-	// v1_55743877f3ffd5fc834e97bc43a6e7bd
+	// v1_d00068b9441e09d87689c7cb06a646a1
 }
 
-func ExampleHash_version() {
+func ExampleHash_tags() {
 	type Person struct {
-		Name   string            `version:"1"`
-		Age    int               `version:"1"`
-		Emails []string          `version:"1"`
-		Extra  map[string]string `version:"1" lastversion:"2"`
-		Spouse *Person           `version:"2"`
+		Ignored  string            `hash:"-"`
+		FullName string            `hash:"Name, version(1)"`
+		Age      int               `hash:",version(1)"`
+		Emails   []string          `hash:",version(1)"`
+		Extra    map[string]string `hash:",version(1) lastversion(2)"`
+		Spouse   *Person           `hash:",version(2)"`
 	}
 	bill := &Person{
-		Name:   "Bill",
-		Age:    24,
-		Emails: []string{"bob@foo.org", "bob@bar.org"},
+		FullName: "Bill",
+		Age:      24,
+		Emails:   []string{"bob@foo.org", "bob@bar.org"},
 		Extra: map[string]string{
 			"facebook": "Bob42",
 		},
 	}
 	bob := &Person{
-		Name:   "Bob",
-		Age:    42,
-		Emails: []string{"bob@foo.org", "bob@bar.org"},
+		FullName: "Bob",
+		Age:      42,
+		Emails:   []string{"bob@foo.org", "bob@bar.org"},
 		Extra: map[string]string{
 			"facebook": "Bob42",
 		},

--- a/structhash_examples_test.go
+++ b/structhash_examples_test.go
@@ -2,6 +2,8 @@ package structhash
 
 import (
 	"fmt"
+	"crypto/md5"
+	"crypto/sha1"
 )
 
 func ExampleHash() {
@@ -83,6 +85,39 @@ func ExampleHash_version() {
 	// v1_461558d2570e10f79693e34ea309d1ad
 	// v2_d00068b9441e09d87689c7cb06a646a1
 	// v3_b5b651c6650939ef4d063d05caa5c778
+}
+
+func ExampleDump() {
+	type Person struct {
+		Name   string
+		Age    int
+		Emails []string
+		Extra  map[string]string
+		Spouse *Person
+	}
+	bill := &Person{
+		Name:   "Bill",
+		Age:    24,
+		Emails: []string{"bob@foo.org", "bob@bar.org"},
+		Extra: map[string]string{
+			"facebook": "Bob42",
+		},
+	}
+	bob := &Person{
+		Name:   "Bob",
+		Age:    42,
+		Emails: []string{"bob@foo.org", "bob@bar.org"},
+		Extra: map[string]string{
+			"facebook": "Bob42",
+		},
+		Spouse: bill,
+	}
+
+	fmt.Printf("md5:  %x\n", md5.Sum(Dump(bob, 1)))
+	fmt.Printf("sha1: %x\n", sha1.Sum(Dump(bob, 1)))
+	// Output:
+	// md5:  d00068b9441e09d87689c7cb06a646a1
+	// sha1: 24c19cd7a9fcfd4d4394e1f6a1874bd8751645e3
 }
 
 func ExampleVersion() {

--- a/structhash_test.go
+++ b/structhash_test.go
@@ -32,6 +32,14 @@ type Tags3 struct {
 	Bar string
 }
 
+type Nils struct {
+	Str   *string
+	Int   *int
+	Bool  *bool
+	Map   map[string]string
+	Slice []string
+}
+
 func dataSetup() *First {
 	tmpmap := make(map[string]string)
 	tmpmap["foo"] = "bar"
@@ -60,7 +68,7 @@ func TestHash(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	// fmt.Println(v1)
+	// fmt.Println(string(Dump(data, 1)))
 	if v1 != v1Hash {
 		t.Errorf("%s is not %s", v1, v1Hash)
 	}
@@ -68,7 +76,7 @@ func TestHash(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	// fmt.Println(v2)
+	// fmt.Println(string(Dump(data, 2)))
 	if v2 != v2Hash {
 		t.Errorf("%s is not %s", v2, v2Hash)
 	}
@@ -104,5 +112,29 @@ func TestTags(t *testing.T) {
 	t3v3_dump := string(Dump(t3, 3))
 	if t1v3_dump != t3v3_dump {
 		t.Errorf("%s is not %s", t1v3_dump, t3v3_dump)
+	}
+}
+
+func TestNil(t *testing.T) {
+	s1 := Nils{
+		Str: nil,
+		Int: nil,
+		Bool: nil,
+		Map: nil,
+		Slice: nil,
+	}
+
+	s2 := Nils{
+		Str: new(string),
+		Int: new(int),
+		Bool: new(bool),
+		Map: make(map[string]string),
+		Slice: make([]string, 0),
+	}
+
+	s1_dump := string(Dump(s1, 1))
+	s2_dump := string(Dump(s2, 1))
+	if s1_dump != s2_dump {
+		t.Errorf("%s is not %s", s1_dump, s2_dump)
 	}
 }

--- a/structhash_test.go
+++ b/structhash_test.go
@@ -19,8 +19,8 @@ type Second struct {
 
 type Tags1 struct {
 	Int int    `hash:"-"`
-	Str string `hash:"Foo, version(1) lastversion(2)"`
-	Bar string `hash:",version(1)"`
+	Str string `hash:"name:Foo version:1 lastversion:2"`
+	Bar string `hash:"version:1"`
 }
 
 type Tags2 struct {

--- a/structhash_test.go
+++ b/structhash_test.go
@@ -1,7 +1,7 @@
 package structhash
 
 import (
-	// "fmt"
+	"fmt"
 	"testing"
 )
 
@@ -56,5 +56,14 @@ func TestHash(t *testing.T) {
 	// fmt.Println(v2)
 	if v2 != v2Hash {
 		t.Errorf("%s is not %s", v2, v2Hash)
+	}
+
+	v1md5 := fmt.Sprintf("v1_%x", Md5(data, 1))
+	if v1md5 != v1Hash {
+		t.Errorf("%s is not %s", v1md5, v1Hash[3:])
+	}
+	v2md5 := fmt.Sprintf("v2_%x", Md5(data, 2))
+	if v2md5 != v2Hash {
+		t.Errorf("%s is not %s", v2md5, v2Hash[3:])
 	}
 }

--- a/structhash_test.go
+++ b/structhash_test.go
@@ -17,6 +17,21 @@ type Second struct {
 	Slice []int             `version:"1"`
 }
 
+type Tags1 struct {
+	Int int    `hash:"-"`
+	Str string `hash:"Foo, version(1) lastversion(2)"`
+	Bar string `hash:",version(1)"`
+}
+
+type Tags2 struct {
+	Foo string
+	Bar string
+}
+
+type Tags3 struct {
+	Bar string
+}
+
 func dataSetup() *First {
 	tmpmap := make(map[string]string)
 	tmpmap["foo"] = "bar"
@@ -65,5 +80,29 @@ func TestHash(t *testing.T) {
 	v2md5 := fmt.Sprintf("v2_%x", Md5(data, 2))
 	if v2md5 != v2Hash {
 		t.Errorf("%s is not %s", v2md5, v2Hash[3:])
+	}
+}
+
+func TestTags(t *testing.T) {
+	t1 := Tags1{11, "foo", "bar"}
+	t1x := Tags1{22, "foo", "bar"}
+	t2 := Tags2{"foo", "bar"}
+	t3 := Tags3{"bar"}
+
+	t1_dump := string(Dump(t1, 1))
+	t1x_dump := string(Dump(t1x, 1))
+	if t1_dump != t1x_dump {
+		t.Errorf("%s is not %s", t1_dump, t1x_dump)
+	}
+
+	t2_dump := string(Dump(t2, 1))
+	if t1_dump != t2_dump {
+		t.Errorf("%s is not %s", t1_dump, t2_dump)
+	}
+
+	t1v3_dump := string(Dump(t1, 3))
+	t3v3_dump := string(Dump(t3, 3))
+	if t1v3_dump != t3v3_dump {
+		t.Errorf("%s is not %s", t1v3_dump, t3v3_dump)
 	}
 }

--- a/structhash_test.go
+++ b/structhash_test.go
@@ -117,18 +117,18 @@ func TestTags(t *testing.T) {
 
 func TestNil(t *testing.T) {
 	s1 := Nils{
-		Str: nil,
-		Int: nil,
-		Bool: nil,
-		Map: nil,
+		Str:   nil,
+		Int:   nil,
+		Bool:  nil,
+		Map:   nil,
 		Slice: nil,
 	}
 
 	s2 := Nils{
-		Str: new(string),
-		Int: new(int),
-		Bool: new(bool),
-		Map: make(map[string]string),
+		Str:   new(string),
+		Int:   new(int),
+		Bool:  new(bool),
+		Map:   make(map[string]string),
 		Slice: make([]string, 0),
 	}
 


### PR DESCRIPTION
Hi!

Thanks for this library :)

**Changelog of this PR**
- add `Dump()`, useful if you want alternative hashing function (instead of md5) or alternative formatting (instead of `v1_...`)
- add `Md5()` and `Sha1()` shorthands for convenience
- rework struct tags
- handle nil values
- improve README (add godoc badge, "Features", "Quick start", "Struct Tags", and "Nil values" sections)

**Struct tags**

This PR suggests the following changes:
- use single `hash:"..."` struct tag instead of `version:""` and `lastversion:""` (however, the latter are still supported for compatibility)
- change default behaviour: use field even if it doesn't contain `version:""` tag
- support ignoring fields: `hash:"-"`
- support renaming fields

See updated README for details. Please let me know if this change can't be accepted as is.

**Nil values**

Currently, `structhash` formats nil pointers, maps, and slices as "invalid value" string. With this PR, it handles nil values as zero-values of pointed type, e.g. nil pointer to string is now equal to empty string.
