### PR TITLE
Add benchmarks and improve performance

### DIFF
--- a/structhash.go
+++ b/structhash.go
@@ -1,6 +1,7 @@
 package structhash
 
 import (
+	"bytes"
 	"crypto/md5"
 	"crypto/sha1"
 	"fmt"
@@ -41,7 +42,7 @@ func Hash(c interface{}, version int) (string, error) {
 // Dump takes a data structure and returns its byte representation. This can be
 // useful if you need to use your own hashing function or formatter.
 func Dump(c interface{}, version int) []byte {
-	return []byte(serialize(c, version))
+	return serialize(c, version)
 }
 
 // Md5 takes a data structure and returns its md5 hash.
@@ -58,112 +59,163 @@ func Sha1(c interface{}, version int) []byte {
 	return sum[:]
 }
 
+type item struct {
+	name  string
+	value reflect.Value
+}
+
+type itemSorter []item
+
+func (s itemSorter) Len() int {
+	return len(s)
+}
+
+func (s itemSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s itemSorter) Less(i, j int) bool {
+	return s[i].name < s[j].name
+}
+
 type structFieldFilter func(reflect.StructField) (string, bool)
 
-func strValue(val reflect.Value, depth int, fltr structFieldFilter) string {
+func writeValue(buf *bytes.Buffer, val reflect.Value, depth int, fltr structFieldFilter) {
 	switch val.Kind() {
 	case reflect.String:
-		return "\"" + val.String() + "\""
+		buf.WriteByte('"')
+		buf.WriteString(val.String())
+		buf.WriteByte('"')
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return fmt.Sprintf("%d", val.Int())
+		buf.WriteString(strconv.FormatInt(val.Int(), 10))
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return fmt.Sprintf("%d", val.Uint())
+		buf.WriteString(strconv.FormatUint(val.Uint(), 10))
 	case reflect.Bool:
 		if val.Bool() {
-			return "true"
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
 		}
-		return "false"
 	case reflect.Ptr:
 		if !val.IsNil() || val.Type().Elem().Kind() == reflect.Struct {
-			return strValue(reflect.Indirect(val), depth, fltr)
+			writeValue(buf, reflect.Indirect(val), depth, fltr)
 		} else {
-			return strValue(reflect.Zero(val.Type().Elem()), depth, fltr)
+			writeValue(buf, reflect.Zero(val.Type().Elem()), depth, fltr)
 		}
 	case reflect.Array, reflect.Slice:
+		buf.WriteByte('[')
 		len := val.Len()
-		ret := "["
 		for i := 0; i < len; i++ {
 			if i != 0 {
-				ret = ret + ", "
+				buf.WriteString(", ")
 			}
-			ret = ret + strValue(val.Index(i), depth+1, fltr)
+			writeValue(buf, val.Index(i), depth+1, fltr)
 		}
-		ret = ret + "]"
-		return ret
+		buf.WriteByte(']')
 	case reflect.Map:
-		len := val.Len()
 		mk := val.MapKeys()
-		strmap := make(map[string]string, len)
-		// Map/serialize all values
-		for i := 0; i < len; i++ {
-			strmap[strValue(mk[i], depth+1, fltr)] =
-				strValue(val.MapIndex(mk[i]), depth+1, fltr)
+		items := make([]item, len(mk), len(mk))
+		// Get all values
+		for i, _ := range items {
+			items[i].name = strValue(mk[i], depth+1, fltr)
+			items[i].value = val.MapIndex(mk[i])
 		}
 
-		// Create array to hold map keys and sort them
-		skey := make([]string, 0, len)
-		for k := range strmap {
-			skey = append(skey, k)
-		}
-		sort.Strings(skey)
+		// Sort values by key
+		sort.Sort(itemSorter(items))
 
-		ret := "["
-		for i := 0; i < len; i++ {
+		buf.WriteByte('[')
+		for i, _ := range items {
 			if i != 0 {
-				ret = ret + ", "
+				buf.WriteString(", ")
 			}
-			ret = ret + skey[i] + ": " + strmap[skey[i]]
+			buf.WriteString(items[i].name)
+			buf.WriteString(": ")
+			writeValue(buf, items[i].value, depth+1, fltr)
 		}
-		ret = ret + "]"
-		return ret
+		buf.WriteByte(']')
 	case reflect.Struct:
 		vtype := val.Type()
 		flen := vtype.NumField()
-		smap := make(map[string]string)
+		items := make([]item, 0, flen)
 		// Get all fields
 		for i := 0; i < flen; i++ {
 			field := vtype.Field(i)
-			name := field.Name
+			it := item{field.Name, val.Field(i)}
 			if fltr != nil {
-				if newname, ok := fltr(field); ok {
-					name = newname
+				if name, ok := fltr(field); ok {
+					it.name = name
 				} else {
 					continue
 				}
 			}
-			fval := val.Field(i)
-			smap[name] = strValue(fval, depth+1, fltr)
+			items = append(items, it)
 		}
-		// Get the keys and sort them
-		skey := make([]string, len(smap))
-		c := 0
-		for k := range smap {
-			skey[c] = k
-			c++
-		}
-		sort.Strings(skey)
+		// Sort fields by name
+		sort.Sort(itemSorter(items))
 
-		flen = len(skey)
-		ret := "{\n"
-		for i := 0; i < flen; i++ {
+		buf.WriteString("{\n")
+		for i, _ := range items {
 			if i != 0 {
-				ret = ret + ", \n"
+				buf.WriteString(", \n")
 			}
-			ret = ret + strings.Repeat("  ", depth+1) + "\"" + skey[i] + "\": "
-			ret = ret + smap[skey[i]]
+			for i := 0; i < depth+1; i++ {
+				buf.WriteString("  ")
+			}
+			buf.WriteByte('"')
+			buf.WriteString(items[i].name)
+			buf.WriteString("\": ")
+			writeValue(buf, items[i].value, depth+1, fltr)
 		}
-		return ret + "\n" + strings.Repeat("  ", depth) + "}"
+		buf.WriteByte('\n')
+		for i := 0; i < depth; i++ {
+			buf.WriteString("  ")
+		}
+		buf.WriteByte('}')
 	default:
-		return val.String()
+		buf.WriteString(val.String())
 	}
 }
 
-func serialize(object interface{}, version int) string {
-	return strValue(reflect.ValueOf(object), 0, func(f reflect.StructField) (string, bool) {
-		var err error
-		name := f.Name
-		ver := 0
-		lastver := -1
+func strValue(val reflect.Value, depth int, fltr structFieldFilter) string {
+	switch val.Kind() {
+	case reflect.String:
+		return "\"" + val.Interface().(string) + "\""
+	default:
+		buf := new(bytes.Buffer)
+		writeValue(buf, val, depth, fltr)
+		return string(buf.Bytes())
+	}
+}
+
+func filterField(f reflect.StructField, version int) (string, bool) {
+	var err error
+	name := f.Name
+	ver := 0
+	lastver := -1
+	if str := f.Tag.Get("hash"); str != "" {
+		if str == "-" {
+			return "", false
+		}
+		for _, tag := range strings.Split(str, " ") {
+			args := strings.Split(strings.TrimSpace(tag), ":")
+			if len(args) != 2 {
+				return "", false
+			}
+			switch args[0] {
+			case "name":
+				name = args[1]
+			case "version":
+				if ver, err = strconv.Atoi(args[1]); err != nil {
+					return "", false
+				}
+			case "lastversion":
+				if lastver, err = strconv.Atoi(args[1]); err != nil {
+					return "", false
+				}
+			}
+		}
+	} else {
 		if str := f.Tag.Get("lastversion"); str != "" {
 			if lastver, err = strconv.Atoi(str); err != nil {
 				return "", false
@@ -174,35 +226,20 @@ func serialize(object interface{}, version int) string {
 				return "", false
 			}
 		}
-		if str := f.Tag.Get("hash"); str != "" {
-			if str == "-" {
-				return "", false
-			}
-			for _, tag := range strings.Split(str, " ") {
-				args := strings.Split(strings.TrimSpace(tag), ":")
-				if len(args) != 2 {
-					return "", false
-				}
-				switch args[0] {
-				case "name":
-					name = args[1]
-				case "version":
-					if ver, err = strconv.Atoi(args[1]); err != nil {
-						return "", false
-					}
-				case "lastversion":
-					if lastver, err = strconv.Atoi(args[1]); err != nil {
-						return "", false
-					}
-				}
-			}
-		}
-		if lastver != -1 && lastver < version {
-			return "", false
-		}
-		if ver > version {
-			return "", false
-		}
-		return name, true
-	}) + "\n"
+	}
+	if lastver != -1 && lastver < version {
+		return "", false
+	}
+	if ver > version {
+		return "", false
+	}
+	return name, true
+}
+
+func serialize(object interface{}, version int) []byte {
+	s := strValue(reflect.ValueOf(object), 0,
+		func(f reflect.StructField) (string, bool) {
+			return filterField(f, version)
+		})
+	return []byte(s+"\n")
 }

--- a/structhash_benchmark_test.go
+++ b/structhash_benchmark_test.go
@@ -1,0 +1,95 @@
+package structhash
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type BenchData struct {
+	Bool   bool
+	String string
+	Int    int
+	Uint   uint
+	Map    map[string]*BenchData
+	Slice  []*BenchData
+	Struct *BenchData
+}
+
+type BenchTags struct {
+	Bool   bool   `json:"f1" hash:"name:f1"`
+	String string `json:"f2" hash:"name:f2"`
+	Int    int    `json:"f3" hash:"name:f3"`
+	Uint   uint   `json:"f4" hash:"name:f4"`
+}
+
+func benchDataSimple() *BenchData {
+	return &BenchData{true, "simple", -123, 321, nil, nil, nil}
+}
+
+func benchDataFull() *BenchData {
+	foo := benchDataSimple()
+	bar := benchDataSimple()
+
+	m := make(map[string]*BenchData)
+	m["foo"] = foo
+	m["bar"] = bar
+
+	s := []*BenchData{
+		foo,
+		bar,
+	}
+
+	return &BenchData{true, "hello", -123, 321, m, s, foo}
+}
+
+func benchDataTags() *BenchTags {
+	return &BenchTags{true, "tags", -123, 321}
+}
+
+func BenchmarkSimpleJSON(b *testing.B) {
+	s := benchDataSimple()
+
+	for i := 0; i < b.N; i++ {
+		json.Marshal(s)
+	}
+}
+
+func BenchmarkSimpleDump(b *testing.B) {
+	s := benchDataSimple()
+
+	for i := 0; i < b.N; i++ {
+		Dump(s, 1)
+	}
+}
+
+func BenchmarkFullJSON(b *testing.B) {
+	s := benchDataFull()
+
+	for i := 0; i < b.N; i++ {
+		json.Marshal(s)
+	}
+}
+
+func BenchmarkFullDump(b *testing.B) {
+	s := benchDataFull()
+
+	for i := 0; i < b.N; i++ {
+		Dump(s, 1)
+	}
+}
+
+func BenchmarkTagsJSON(b *testing.B) {
+	s := benchDataTags()
+
+	for i := 0; i < b.N; i++ {
+		json.Marshal(s)
+	}
+}
+
+func BenchmarkTagsDump(b *testing.B) {
+	s := benchDataTags()
+
+	for i := 0; i < b.N; i++ {
+		Dump(s, 1)
+	}
+}

--- a/structhash_examples_test.go
+++ b/structhash_examples_test.go
@@ -38,7 +38,7 @@ func ExampleHash() {
 	}
 	fmt.Printf("%s", hash)
 	// Output:
-	// v1_d00068b9441e09d87689c7cb06a646a1
+	// v1_6a50d73f3bd0b9ebd001a0b610f387f0
 }
 
 func ExampleHash_tags() {
@@ -83,9 +83,9 @@ func ExampleHash_tags() {
 	fmt.Printf("%s\n", hashV2)
 	fmt.Printf("%s\n", hashV3)
 	// Output:
-	// v1_a4500d206f830e75bb4b362705ee6240
-	// v2_67caf9d9f9d2922ecc6f997bace6f06c
-	// v3_a10f69ec95d652fc16f5f744a554e624
+	// v1_45d8a54c5f5fd287f197b26d128882cd
+	// v2_babd7618f29036f5564816bee6c8a037
+	// v3_012b06239f942549772c9139d66c121e
 }
 
 func ExampleDump() {
@@ -117,8 +117,8 @@ func ExampleDump() {
 	fmt.Printf("md5:  %x\n", md5.Sum(Dump(bob, 1)))
 	fmt.Printf("sha1: %x\n", sha1.Sum(Dump(bob, 1)))
 	// Output:
-	// md5:  d00068b9441e09d87689c7cb06a646a1
-	// sha1: 24c19cd7a9fcfd4d4394e1f6a1874bd8751645e3
+	// md5:  6a50d73f3bd0b9ebd001a0b610f387f0
+	// sha1: c45f097a37366eaaf6ffbc7357c2272cd8fb64f6
 }
 
 func ExampleVersion() {

--- a/structhash_test.go
+++ b/structhash_test.go
@@ -60,8 +60,8 @@ func dataSetup() *First {
 }
 
 func TestHash(t *testing.T) {
-	v1Hash := "v1_19a51ad2e72bc84e8c35dcdfe55e4d79"
-	v2Hash := "v2_00a9b29c4d344aec8114c76b324757c0"
+	v1Hash := "v1_39f4bc683762286061af1484d1d05c0b"
+	v2Hash := "v2_9504d3f08564b00903ba2c41325981d8"
 
 	data := dataSetup()
 	v1, err := Hash(data, 1)
@@ -115,7 +115,7 @@ func TestTags(t *testing.T) {
 	}
 }
 
-func TestNil(t *testing.T) {
+func TestNils(t *testing.T) {
 	s1 := Nils{
 		Str:   nil,
 		Int:   nil,


### PR DESCRIPTION
Hi!

**Changelog**

This PR adds benchmarks comparing `json.Marshal` and `structhash.Dump`.

There are three kinds of benchmarks:
- simple: serialize struct without struct tags, maps, slices, and nested structs
- full: serialize struct without struct tags, but with maps, slices, and nested structs
- tags: serialize struct with struct tags

This PR also introduces some obvious optimizations:
- use `bytes.Buffer` instead of string concatenation
- use more compact encoding (and drop indentation)
- try to reduce number of allocations

**Results**

_Before this PR_

```
BenchmarkSimpleJSON-4     500000          3066 ns/op
BenchmarkSimpleDump-4     100000         11745 ns/op
BenchmarkFullJSON-4       100000         16801 ns/op
BenchmarkFullDump-4        20000         85045 ns/op
BenchmarkTagsJSON-4      1000000          1763 ns/op
BenchmarkTagsDump-4       200000         10534 ns/op
```

_After this PR_

```
BenchmarkSimpleJSON-4     500000          3039 ns/op
BenchmarkSimpleDump-4     300000          4910 ns/op
BenchmarkFullJSON-4       100000         16665 ns/op
BenchmarkFullDump-4        50000         29468 ns/op
BenchmarkTagsJSON-4      1000000          1761 ns/op
BenchmarkTagsDump-4       300000          5390 ns/op
```

**Further improvements**

This PR improves performance (~2x ans sometimes more), but `structhash` is still slower than `json.Marshal`, which is not the [fastest serializer](https://github.com/alecthomas/go_serialization_benchmarks) itself.

Why `structhash` is slower:
- `reflect` is slow, and `json.Marshal` caches information about types, while `structhash` doesn't
- `structhash` probably performs some unnecessary allocations
- `structhash` sorts struct keys
- `structhash` handles struct tags inefficiently

To improve performance, we can:
- cache type information retrieved from reflect
- cache sorted struct fields
- improve encoding even more (probably switch to binary encoding)
- improve struct tags parsing
- try to reduce allocations even more

I believe it's possible to make `structhash` as fast as other reflection-based serializers (e.g. [this one](https://github.com/vmihailenco/msgpack)) which are several times faster than `json.Marshal`.
