### PR TITLE
Sc 25682 cache refactor key generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/talon-one/structhash
+
+go 1.18

--- a/structhash.go
+++ b/structhash.go
@@ -86,7 +86,7 @@ func (e tagError) Error() string {
 
 type structFieldFilter func(reflect.StructField, *item) (bool, error)
 
-type NilPtr struct{}
+const nilPtrValue = "_nil"
 
 func writeValue(buf *bytes.Buffer, val reflect.Value, fltr structFieldFilter) {
 	switch val.Kind() {
@@ -107,17 +107,11 @@ func writeValue(buf *bytes.Buffer, val reflect.Value, fltr structFieldFilter) {
 			buf.WriteByte('f')
 		}
 	case reflect.Ptr:
-		if !val.IsNil() || val.Type().Elem().Kind() == reflect.Struct {
-			writeValue(buf, reflect.Indirect(val), fltr)
-		} else {
-			writeValue(buf, reflect.Zero(val.Type().Elem()), fltr)
-		}
-
 		if val.IsNil() {
 			if val.Type().Elem().Kind() == reflect.Struct {
 				writeValue(buf, reflect.Indirect(val), fltr)
 			} else {
-				writeValue(buf, reflect.ValueOf(NilPtr{}), fltr)
+				writeValue(buf, reflect.ValueOf(nilPtrValue), fltr)
 			}
 		} else {
 			writeValue(buf, reflect.Indirect(val), fltr)
@@ -125,7 +119,7 @@ func writeValue(buf *bytes.Buffer, val reflect.Value, fltr structFieldFilter) {
 
 	case reflect.Array, reflect.Slice:
 		if val.IsNil() {
-			writeValue(buf, reflect.ValueOf(NilPtr{}), fltr)
+			writeValue(buf, reflect.ValueOf(nilPtrValue), fltr)
 		} else {
 			buf.WriteByte('[')
 			len := val.Len()
@@ -140,7 +134,7 @@ func writeValue(buf *bytes.Buffer, val reflect.Value, fltr structFieldFilter) {
 
 	case reflect.Map:
 		if val.IsNil() {
-			writeValue(buf, reflect.ValueOf(NilPtr{}), fltr)
+			writeValue(buf, reflect.ValueOf(nilPtrValue), fltr)
 		} else {
 			mk := val.MapKeys()
 			items := make([]item, len(mk), len(mk))

--- a/structhash_test.go
+++ b/structhash_test.go
@@ -162,16 +162,8 @@ func TestNils(t *testing.T) {
 		Slice: nil,
 	}
 
-	s2 := Nils{
-		Str:   new(string),
-		Int:   new(int),
-		Bool:  new(bool),
-		Map:   make(map[string]string),
-		Slice: make([]string, 0),
-	}
-
 	s1_dump := string(Dump(s1, 1))
-	s2_dump := string(Dump(s2, 1))
+	s2_dump := `{Bool:"_nil",Int:"_nil",Map:"_nil",Slice:"_nil",Str:"_nil"}`
 	if s1_dump != s2_dump {
 		t.Errorf("%s is not %s", s1_dump, s2_dump)
 	}


### PR DESCRIPTION
This PR would replace all `nil` values by the string "__nil" in the generated dump. This would allow us to differentiate `nil` values in the resulting dump, in order to generate unique hash values for structs, event if they have nil values.